### PR TITLE
resolving ambiguities in forest/trees

### DIFF
--- a/src/forest.tmpl.h
+++ b/src/forest.tmpl.h
@@ -452,8 +452,7 @@ std::set<std::pair<NodeT, std::set<std::vector<NodeT>>>>
 template <typename NodeT>
 size_t forest<NodeT>::count_trees(const node& root) const {
 	std::map<node, size_t> ndc;
-	bool isoverflow = false;
-	auto cb_exit = [&ndc, &isoverflow](const node& croot, auto& ambset) {
+	auto cb_exit = [&ndc](const node& croot, auto& ambset) {
 		for (auto& pack : ambset) {
 			size_t pkc = 1; // count of the pack
 			for (auto& sym : pack)
@@ -461,7 +460,7 @@ size_t forest<NodeT>::count_trees(const node& root) const {
 					size_t x = pkc * ndc[sym];
 					if( pkc != 0 && x / pkc != ndc[sym]  ) {
 						MS(std::cout<<"Overflow\n");
-						isoverflow = true;
+						ndc[croot]=SIZE_MAX;
 						return;
 					}
 					pkc = x;
@@ -470,7 +469,6 @@ size_t forest<NodeT>::count_trees(const node& root) const {
 		}
 	};
 	traverse(root, NO_ENTER, cb_exit);
-	if(isoverflow) ndc[root] = 0; // mark it to be zero
 	return ndc[root];
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -21,6 +21,7 @@
 #include <istream>
 #include <span>
 #include <cassert>
+#include <algorithm>
 #include "memory_map.h"
 #include "defs.h"
 #include "characters.h"
@@ -266,6 +267,7 @@ public:
 		decoder_type chars_to_terminals = 0;
 		encoder_type terminals_to_chars = 0;
 		bool auto_disambiguate = true;
+		std::vector<std::string> nodisambg_list = {};
 	};
 	// constructor
 	parser(grammar<C, T>& g, options o = {});

--- a/src/parser.h
+++ b/src/parser.h
@@ -265,6 +265,7 @@ public:
 		size_t gc_lag = 1;
 		decoder_type chars_to_terminals = 0;
 		encoder_type terminals_to_chars = 0;
+		bool auto_disambiguate = true;
 	};
 	// constructor
 	parser(grammar<C, T>& g, options o = {});
@@ -380,7 +381,6 @@ private:
 	bool init_forest(pforest& f, const lit<C, T>& start_lit);
 	bool build_forest(pforest& f, const pnode& root);
 	bool binarize_comb(const item&, std::set<std::vector<pnode>>&);
-	size_t last_prod;
 	void sbl_chd_forest(const item&,
 		std::vector<pnode>&, size_t, std::set<std::vector<pnode>>&);
 	std::unique_ptr<pforest> _parse(int_t start = -1);

--- a/src/parser.h
+++ b/src/parser.h
@@ -380,6 +380,7 @@ private:
 	bool init_forest(pforest& f, const lit<C, T>& start_lit);
 	bool build_forest(pforest& f, const pnode& root);
 	bool binarize_comb(const item&, std::set<std::vector<pnode>>&);
+	size_t last_prod;
 	void sbl_chd_forest(const item&,
 		std::vector<pnode>&, size_t, std::set<std::vector<pnode>>&);
 	std::unique_ptr<pforest> _parse(int_t start = -1);

--- a/src/parser.tmpl.h
+++ b/src/parser.tmpl.h
@@ -1006,7 +1006,7 @@ bool parser<C, T>::build_forest(pforest& f, const pnode& root) {
 	//auto& nxtset = sorted_citem[root.n()][root.second[0]];
 	auto &nxtset = sorted_citem[{ root.first.n(), root.second[0] }];
 	
-	pnodes_set ambset;
+	pnodes_set ambset, cambset;
 	std::set<pnode> snodes;
 	size_t last_p = SIZE_MAX;
 	for (auto& curp : nxtset) {
@@ -1015,65 +1015,74 @@ bool parser<C, T>::build_forest(pforest& f, const pnode& root) {
 		pnode cnode(completed(cur) /*&& !negative(cur)*/
 			? g(cur.prod) : g.nt(root.first.n()),
 			{ cur.from, cur.set });
-		pnodes_set cambset;
-		if (o.binarize) binarize_comb(cur, cambset);
+		cambset.clear();
+		if (o.binarize) binarize_comb(cur, 
+						o.auto_disambiguate ? cambset : ambset);
 		else {
 			pnodes nxtlits;
 			//std::cout << "\n" << cur.prod << " " << last_p << " " << ambset.size();
-			sbl_chd_forest(cur, nxtlits, cur.from, cambset);
+			sbl_chd_forest(cur, nxtlits, cur.from, 
+						o.auto_disambiguate ? cambset : ambset);
 		}
 
 		// resolve ambiguity across productions, due to different earley items
 		// with different prod id
-		if(cambset.size()) {
-			if( ambset.size() == 0)
-				last_p = cur.prod, ambset = cambset;
-			else if ( cur.prod < last_p)
-				ambset.clear(), last_p = cur.prod, ambset = cambset;	
+		if( o.auto_disambiguate ) {
+			if(cambset.size()) { // any new sub forest
+				if( ambset.size() == 0) // first time if
+					last_p = cur.prod, ambset = cambset;
+				else if ( cur.prod < last_p) // get the smallest one
+					ambset.clear(), last_p = cur.prod, ambset = cambset;	
+			}
+			
+			snodes.insert(cnode);
 		}		
 		f[cnode] = ambset;
-		snodes.insert(cnode);	
 		//std::cout << "\n A " << cur.prod << " " << last_p << " " << ambset.size();
 	}
 
-	// resolve ambiguity WITHIN production, where same production with same symbols 
-	// of different individual span
-	std::vector<int> gi; 
-	int gspan = -1;
-	int k = 0;
-	std::vector<int> idxs;
-	for(size_t i = 0; i <ambset.size(); i++)
-		idxs.push_back(i);
+	if( o.auto_disambiguate) {
+		
+		// resolve ambiguity if WITHIN production, where same production with same symbols 
+		// of different individual span
+		std::vector<int> gi; 
+		int gspan = -1;
+		int k = 0;
+		std::vector<int> idxs;
+		for(size_t i = 0; i <ambset.size(); i++)
+			idxs.push_back(i);
 
-	do {
-		gi.clear();
-		for (auto packidx : idxs) {
-			auto apack = *next(ambset.begin(), packidx);
-			pnode lt = apack[k];
-			int span = lt.second[1] - lt.second[0];
-			if (gspan == span) gi.push_back(k);
-			if (gspan < span ) gspan = span, gi.clear(), gi.push_back(k);
-			
+		//choose the one with the first smallest span
+		do {
+			gi.clear();
+			for (auto packidx : idxs) {
+				auto apack = *next(ambset.begin(), packidx);
+				pnode lt = apack[k];
+				int span = lt.second[1] - lt.second[0];
+				if (gspan == span) gi.push_back(k);
+				if (gspan < span ) gspan = span, gi.clear(), gi.push_back(k);
+				
+			}
+			k++;
+			idxs.clear();
+			idxs.insert(idxs.begin(),gi.begin(),gi.end());
+			std::cout<<k;
 		}
-		k++;
-		idxs.clear();
-		idxs.insert(idxs.begin(),gi.begin(),gi.end());
-		std::cout<<k;
-	}
-	while( k < int(ambset.size()) && gi.size() > 1 );
-	//std::cout << gi.size() << std::endl;
+		while( k < int(ambset.size()) && gi.size() > 1 );
 
-	pnodes_set cambset;
-	if(ambset.size())
-		cambset.insert(*next(ambset.begin(), gi[0]));
+		cambset.clear();
+		if(ambset.size())
+			cambset.insert(*next(ambset.begin(), gi[0]));
 
 	//std::cout <<" camb "<< cambset.size() << std::endl;
-	if(snodes.size()) { 
-		DBG( assert(snodes.size() == 1));
-		f[*snodes.begin()] = cambset;
+		if(snodes.size()) { 
+			DBG( assert(snodes.size() == 1));
+			f[*snodes.begin()] = cambset;
+		}
+	//std::cout << gi.size() << std::endl;
 	}
-
-	for (auto& aset : cambset)
+	
+	for (auto& aset : o.auto_disambiguate? cambset : ambset)
 		for (const pnode& nxt : aset) build_forest(f, nxt);
 
 	return true;

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
 *******************************************************************************/
 	// 
 	TEST("disambig", "same")
-	ps(start, start + plus +start );
+	ps(start, start + plus + start );
 	ps(start, one);
 	run_test<char>(ps, nt, start, "1+1+1", {}, o);
 	ps.clear();

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -16,8 +16,7 @@ int main(int argc, char **argv)
 
 	prods<> ps, start(nt("start")), nll(lit<>{}),
 		alnum(nt("alnum")), alpha(nt("alpha")), digit(nt("digit")),
-		chars(nt("chars")), expression(nt("expression")), space(nt("space")),
-		spaces(nt("spaces")),
+		chars(nt("chars")), expression(nt("expression")),
 		sum(nt("sum")),	mul(nt("mul")), nzdigit(nt("nzdigit")),
 		m1(nt("m1")), s1(nt("s1")), m2(nt("m2")), s2(nt("s2")),
 		identifier(nt("identifier")), keyword(nt("keyword")),

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -16,11 +16,12 @@ int main(int argc, char **argv)
 
 	prods<> ps, start(nt("start")), nll(lit<>{}),
 		alnum(nt("alnum")), alpha(nt("alpha")), digit(nt("digit")),
-		chars(nt("chars")), expression(nt("expression")),
+		chars(nt("chars")), expression(nt("expression")), space(nt("space")),
+		spaces(nt("spaces")),
 		sum(nt("sum")),	mul(nt("mul")), nzdigit(nt("nzdigit")),
 		m1(nt("m1")), s1(nt("s1")), m2(nt("m2")), s2(nt("s2")),
 		identifier(nt("identifier")), keyword(nt("keyword")),
-		a('a'), b('b'), c('c'), n('n'), p('p'), m('m'),
+		a('a'), b('b'), c('c'), n('n'), p('p'), m('m'), e('e'),
 		A(nt("A")), B(nt("B")), T(nt("T")), X(nt("X")), Y(nt("Y")),
 		zero('0'), one('1'), PO(nt("PO")), IO(nt("IO")),
 		plus('+'), minus('-'), mult('*'),
@@ -202,9 +203,11 @@ int main(int argc, char **argv)
 	ps.clear();
 
 	TEST("papers", "recursion_npnmn")
-	ps(start, n | (start + X + start));
-	ps(X,     p | m);
-	run_test<char>(ps, nt, start, "npnmn", {}, o);
+	ps(start, n);
+	ps(start,  start + p + start);
+	ps(start, start + m + start );
+	ps(start, start + e + start);
+	run_test<char>(ps, nt, start, "npnmnen", {}, o);
 	ps.clear();
 
 	// thesis van, figure 4.11
@@ -220,6 +223,16 @@ int main(int argc, char **argv)
 	ps(start,       plus + start | start + plus + start |
 			start + plus | one);
 	run_test<char>(ps, nt, start, "1+++1", {}, o);
+	ps.clear();
+
+/*******************************************************************************
+*       DISAMBIGUATION
+*******************************************************************************/
+	// 
+	TEST("disambig", "same")
+	ps(start, start + plus +start );
+	ps(start, one);
+	run_test<char>(ps, nt, start, "1+1+1", {}, o);
 	ps.clear();
 
 /*******************************************************************************

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -370,6 +370,7 @@ void help(const std::string& opt) {
 "	-[enable|disable]_binarization\n" <<
 "\t              enables binarization and leftright optimization of forest\n" <<
 "	-[enable|disable]_gc	enables garbage collection\n" <<
+"	-[enable|disable]_autodisambg enable/disable auto disambiguation" <<
 "	-unique_node\n" <<
 "	              retrieves graphs from forest based on nodes, not edges\n"
 "	-stop_after_[1|5]\n" <<
@@ -387,6 +388,7 @@ void process_args(int argc, char **argv) {
 	bool binarize = false;
 	bool incr_gen = false;
 	bool enable_gc = false;
+	bool auto_disambg = false;
 
 	std::vector<std::string> args(argv + 1, argv + argc);
 
@@ -461,7 +463,10 @@ void process_args(int argc, char **argv) {
 			}
 			id(result);
 		}
+		else if (opt == "-enable_autodisambg") auto_disambg = true;
+		else if ( opt == "-disable_autodisambg") auto_disambg = false;
 		else if (opt == "-help" || opt == "-h") help(""), exit(0);
+
 		else help(opt), exit(1);
 	}
 	if (verbosity > 0) {
@@ -475,6 +480,8 @@ void process_args(int argc, char **argv) {
 	options<char>.incr_gen_forest =	options<char32_t>.incr_gen_forest =
 								incr_gen;
 	options<char>.enable_gc = options<char32_t>.enable_gc = enable_gc;
+	options<char>.auto_disambiguate = options<char32_t>.auto_disambiguate = 
+								auto_disambg;
 }
 
 } // namespace idni::testing

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -112,7 +112,7 @@ int test_out(int c, const grammar<T>& g, const std::basic_string<T>& inputstr,
 	std::stringstream ptd;
 	std::stringstream ssf;
 
-	g.print_internal_grammar(ssf, "\\l");
+	g.print_internal_grammar(ssf, "\\l", true);
 	std::string s = ssf.str();
 	ssf.str({});
 

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -370,7 +370,8 @@ void help(const std::string& opt) {
 "	-[enable|disable]_binarization\n" <<
 "\t              enables binarization and leftright optimization of forest\n" <<
 "	-[enable|disable]_gc	enables garbage collection\n" <<
-"	-[enable|disable]_autodisambg enable/disable auto disambiguation" <<
+"	-[enable|disable]_autodisambg enable/disable auto disambiguation\n" <<
+"	-[no_disambg nt1,nt2..ntn] disables disambiguation for specified non-terminals\n"
 "	-unique_node\n" <<
 "	              retrieves graphs from forest based on nodes, not edges\n"
 "	-stop_after_[1|5]\n" <<
@@ -465,8 +466,17 @@ void process_args(int argc, char **argv) {
 		}
 		else if (opt == "-enable_autodisambg") auto_disambg = true;
 		else if ( opt == "-disable_autodisambg") auto_disambg = false;
+		else if ( opt == "-no_disambg" ) {
+			++it;
+			if( it == args.end()) missing(opt); 
+			std::stringstream ss(*it);
+			std::string nt;
+			while(getline(ss, nt, ',')){
+				options<char>.nodisambg_list.push_back(nt),
+				options<char32_t>.nodisambg_list.push_back(nt);
+			}
+		}
 		else if (opt == "-help" || opt == "-h") help(""), exit(0);
-
 		else help(opt), exit(1);
 	}
 	if (verbosity > 0) {


### PR DESCRIPTION
resolving ambiguities in forest/trees
* across different productions
* due to same production selection based on p and size of item span
+ tests

E -> E + E
E -> E * E
E -> E ^ E

Here you can have precedence by the listing order . ^ > * > +.

For 1+1+1, the following is also ambiguous
E -> E+E
E -> 1 
We pick the one with shortest span of earley item first.
