### PR TITLE
Refactoring node of forest in order to avoid multiple copies of the s…

### DIFF
--- a/examples/basic_arithmetic/main.cpp
+++ b/examples/basic_arithmetic/main.cpp
@@ -65,7 +65,7 @@ private:
 	}
 	int_t evaluate(parser<char>::result& res) {
 		vector<int_t> x;  // intermediate evaluations (nested)
-		auto cb_enter = [&x, &res, this](const auto& n) {
+		auto cb_enter = [&x, &res, this](const parser<char>::pnode& n) {
 			//DBG(cout << "entering: `" << n.first.to_std_string() << "` ["<<n.second[0]<<","<<n.second[1]<<"]\n";)
 			if (n.first == integer) {
 				auto i = res.get_terminals_to_int(n);
@@ -73,7 +73,7 @@ private:
 				else x.push_back(i.value());
 			}
 		};
-		auto cb_exit = [&x, this](const auto& n, const auto&) {
+		auto cb_exit = [&x, this](const parser<char>::pnode& n, const auto&) {
 			//DBG(cout << "exiting: `" << n.first.to_std_string() << "`\n";)
 			const auto& l = n.first;
 			if      (l == neg) x.back() = -x.back();

--- a/examples/basic_arithmetic_tgf/main.cpp
+++ b/examples/basic_arithmetic_tgf/main.cpp
@@ -51,7 +51,7 @@ private:
 	size_t id(const string& s) { return nts.get(s); }
 	int_t evaluate(parser<char>::result& r) {
 		vector<int_t> x;  // intermediate evaluations (nested)
-		auto cb_enter = [&x, &r, this](const auto& n) {
+		auto cb_enter = [&x, &r, this](const parser<char>::pnode& n) {
 			//DBG(cout << "entering: `" << n.first.to_std_string() << "` ["<<n.second[0]<<","<<n.second[1]<<"]\n";)
 			if (n.first.nt() && n.first.n() == id("integer")) {
 				auto i = r.get_terminals_to_int(n);
@@ -59,7 +59,7 @@ private:
 				else x.push_back(i.value());
 			}
 		};
-		auto cb_exit = [&x, this](const auto& n, const auto&) {
+		auto cb_exit = [&x, this](const parser<char>::pnode& n, const auto&) {
 			//DBG(cout << "exiting: `" << n.first.to_std_string() << "`\n";)
 			if (!n.first.nt()) return;
 			const auto& l = n.first.n();

--- a/examples/csv_parser10/main.cpp
+++ b/examples/csv_parser10/main.cpp
@@ -73,12 +73,12 @@ struct csv_reader {
 			return i.value();
 		};
 		auto cb_enter = [&r, &get_int, &res, this](const auto& n) {
-			if (!n.first.nt()) return;
+			if (!n->first.nt()) return;
 			// generated csv_parser contains enum containing all
 			// nonterminals from the grammar with their id values.
 			// These can be used to compare with result of call
 			// to literal's method n()
-			auto id = n.first.n();
+			auto id = n->first.n();
 			if      (id == csv_parser::row) r.emplace_back();
 			else if (id == csv_parser::integer)
 				r.back().push_back(get_int(n));

--- a/examples/csv_parser5/main.cpp
+++ b/examples/csv_parser5/main.cpp
@@ -107,7 +107,7 @@ private:
 			return i.value();
 		};
 		// define a callback called when the traversal enters a node n
-		auto cb_enter = [&v, &get_int, &res, this](const auto& n) {
+		auto cb_enter = [&v, &get_int, &res, this](const parser<>::pnode& n) {
 			// n is a pair of a literal and its span
 			// we can compare the literal with literals predefined
 			// as members of 'this' object: integer/str/nullvalue

--- a/examples/csv_parser6/main.cpp
+++ b/examples/csv_parser6/main.cpp
@@ -97,7 +97,7 @@ private:
 				<< numeric_limits<int_t>::max() << '\n', false;
 			return i.value();
 		};
-		auto cb_enter = [&r, &get_int, &res, this](const auto& n) {
+		auto cb_enter = [&r, &get_int, &res, this](const parser<>::pnode& n) {
 			// n is a pair of a literal and its range
 			// we can compare the literal with literals predefined
 			// as members of 'this' object: integer/str/nullvalue

--- a/examples/csv_parser7/main.cpp
+++ b/examples/csv_parser7/main.cpp
@@ -104,7 +104,8 @@ private:
 				<< numeric_limits<int_t>::max() << '\n', false;
 			return i.value();
 		};
-		auto cb_enter = [&r, &get_int, &res, this](const auto& n) {
+		auto cb_enter = [&r, &get_int, &res, this](const auto& _n) {
+			const parser<>::pnode& n = _n;
 			// for every new row we add a new row into r
 			if (n.first == row_) r.emplace_back();
 			else if (n.first == integer)

--- a/examples/csv_parser8/main.cpp
+++ b/examples/csv_parser8/main.cpp
@@ -88,7 +88,7 @@ private:
 				<< numeric_limits<int_t>::max() << '\n', false;
 			return i.value();
 		};
-		auto cb_enter = [&r, &get_int, &res, this](const auto& n) {
+		auto cb_enter = [&r, &get_int, &res, this](const parser<>::pnode& n) {
 			// we care only for nonterminals, so skip terminals
 			if (!n.first.nt()) return;
 			// get name of the nonterminal

--- a/examples/csv_parser9/main.cpp
+++ b/examples/csv_parser9/main.cpp
@@ -80,8 +80,8 @@ private:
 			return i.value();
 		};
 		auto cb_enter = [&r, &get_int, &res, this](const auto& n) {
-			if (!n.first.nt()) return;
-			string nt = nts.get(n.first.n());
+			if (!n->first.nt()) return;
+			string nt = nts.get(n->first.n());
 			if (nt == "row") r.emplace_back();
 			else if (nt == "integer")
 				r.back().push_back(get_int(n));

--- a/src/devhelpers.h
+++ b/src/devhelpers.h
@@ -85,7 +85,7 @@ bool to_dot(std::ostream& ss, P& g, const std::string& inputstr,
 		while (!stk.empty()) {
 			typename parser<C, T>::psptree cur = stk.back();
 			stk.pop_back();
-			if (!cur->value.first.nt()) continue;
+			if (!cur->value->first.nt()) continue;
 			auto key = keyfun(cur->value);
 			ss << "\n" << pointerid(cur) << "["<<"label=\"" <<
 				key.second << "\"];";
@@ -148,8 +148,8 @@ bool to_tml_facts(std::ostream& ss, const typename parser<C, T>::result& r){
 	auto& e = n_e.second;
 	for (size_t i = 0; n.size() && i < n.size()-1; ++i)
 		ss << "node(" << i << " " <<
-			/*std::quoted(*/n[i].first.to_std_string()/*)*/<< " " <<
-			n[i].second[0] << " " << n[i].second[1] << ").\n";
+			/*std::quoted(*/n[i]->first.to_std_string()/*)*/<< " " <<
+			n[i]->second[0] << " " << n[i]->second[1] << ").\n";
 	for (auto& x : e) ss << "edge(" << x.first << " " << x.second <<").\n";
 	return true;
 }

--- a/src/forest.h
+++ b/src/forest.h
@@ -139,7 +139,7 @@ struct forest {
 	/// dependency if any. deletes from graph g as well.
 	/// return true if any one of the nodes' replacement
 	/// succeeds
-	bool replace_nodes(graph& g, std::vector<NodeT>& s);
+	bool replace_nodes(graph& g, nodes& s);
 	/// replaces node 'torep' in one pass with the given nodes
 	/// 'replacement' everywhere in the forest and returns true
 	/// if changed. Does not care if its recursive or cyclic, its

--- a/src/forest.h
+++ b/src/forest.h
@@ -41,12 +41,36 @@ namespace idni {
 // no cycles and no sharing implies its a tree
 
 template <typename NodeT>
-struct forest {
-	using node       = NodeT;
+struct forest { 
+	struct nptr_t {
+		const NodeT *id;	
+	
+		nptr_t(const NodeT *_id = nullptr) : id(_id) { }
+
+		inline operator NodeT() const{
+			return *id;
+		}
+		//inline const NodeT& getobj() const { return *id; }
+		inline const NodeT* operator->() const { return id;}
+		inline bool operator<(const nptr_t& rhs) const {
+			return id < rhs.id;
+		}
+		inline bool operator == (const nptr_t& rhs) const {
+			return id == rhs.id;
+		}
+		//inline lit<C,T> &first() const { DBG(assert(id!=0)); return id->first; }
+		//inline std::array<size_t, 2>& second() const { DBG(assert(id!=0)); return id->second; } 	
+	};
+
+	using node       = nptr_t;
 	using nodes      = std::vector<node>;
 	using nodes_set  = std::set<nodes>;
 	using node_graph = std::map<node, nodes_set>;
 	using edge       = std::pair<size_t, size_t>;
+	public:
+	
+	// node pointer in forerst
+	
 	struct tree {
 		node value;
 		std::vector<std::shared_ptr<struct tree>> child;

--- a/src/forest.tmpl.h
+++ b/src/forest.tmpl.h
@@ -346,11 +346,12 @@ bool forest<NodeT>::_traverse(const node_graph& g, const node& root,
 }
 
 template <typename NodeT>
-bool forest<NodeT>::replace_nodes(graph& g, std::vector<NodeT>& s) {
+bool forest<NodeT>::replace_nodes(graph& g, nodes& s) {
 	bool changed = false;
 	for (auto& n : s) {
 		//DBG(assert(g[n].size() == 1);)
-		if (replace_node(g, n, *(g[n].begin())))
+		if (g.find(n) != g.end() &&
+				replace_node(g, n, *(g[n].begin())))
 			changed = true, g.erase(n);
 	}
 	return changed;

--- a/src/parser.h
+++ b/src/parser.h
@@ -220,16 +220,15 @@ public:
 	struct pnode : public node_type {
 		//using pnodebase::pnodebase;
 		private:
-		// every pnode object has its pointer
-       	static std::map<const pnode, typename forest<pnode>::node> nid;
-       	//static std::vector<const pnode*> rnid;       
+	  	//static std::vector<const pnode*> rnid;       
        	static typename forest<pnode>::node ptrof(const pnode& p);
 		//static pnode& pndof(const nptr_t& );
 		public:
 		pnode(){}
 		pnode(const lit<C,T> &_f, const std::array<size_t,2> &_s): 
 			node_type(_f,_s) {}
-		
+			// every pnode object has its pointer
+       	static std::map<const pnode, typename forest<pnode>::node> nid;
 		inline operator typename forest<pnode>::node() const {
 			return ptrof(*this);
 		}

--- a/src/parser.h
+++ b/src/parser.h
@@ -216,8 +216,27 @@ public:
 	using location_type   = std::array<size_t, 2>;
 	using node_type       = std::pair<symbol_type, location_type>;
 	using parser_type     = idni::parser<char_type, terminal_type>;
-	using pnode           = node_type;
-	using pforest         = forest<pnode>;
+	
+	struct pnode : public node_type {
+		//using pnodebase::pnodebase;
+		private:
+		// every pnode object has its pointer
+       	static std::map<const pnode, typename forest<pnode>::node> nid;
+       	//static std::vector<const pnode*> rnid;       
+       	static typename forest<pnode>::node ptrof(const pnode& p);
+		//static pnode& pndof(const nptr_t& );
+		public:
+		pnode(){}
+		pnode(const lit<C,T> &_f, const std::array<size_t,2> &_s): 
+			node_type(_f,_s) {}
+		
+		inline operator typename forest<pnode>::node() const {
+			return ptrof(*this);
+		}
+		//inline lit<C,T> &first() const { return this->first; }
+		//inline std::array<size_t, 2>& second() const { return this->second; } 	
+	};
+	using pforest		  = forest<pnode>;
 	using pnodes          = pforest::nodes;
 	using pnodes_set      = pforest::nodes_set;
 	using pnode_graph     = pforest::node_graph;
@@ -409,7 +428,7 @@ public:
 		lit<C, T> amb_node{};
 		// recursive part of get_shaped_tree()
 		void _get_shaped_tree_children(const shaping_options& opts,
-			const std::vector<pnode>& nodes,
+			const pnodes& nodes,
 			std::vector<psptree>& child) const;
 	};
 	// parse options for parse() call
@@ -502,9 +521,9 @@ private:
 	bool init_forest(pforest& f, const lit<C, T>& start_lit,
 		const parse_options& po);
 	bool build_forest(pforest& f, const pnode& root);
-	bool binarize_comb(const item&, std::set<std::vector<pnode>>&);
+	bool binarize_comb(const item&, pnodes_set&);
 	void sbl_chd_forest(const item&,
-		std::vector<pnode>&, size_t, std::set<std::vector<pnode>>&);
+		pnodes&, size_t, pnodes_set&);
 #ifdef DEBUG
 	template <typename CharU>
 	friend std::ostream& operator<<(std::ostream& os, lit<C, T>& l);

--- a/src/parser.tmpl.h
+++ b/src/parser.tmpl.h
@@ -23,6 +23,26 @@ using namespace idni::term;
 static inline term::colors TC;
 
 template <typename C, typename T>
+std::map<const typename parser<C,T>::pnode, 
+	typename forest<typename parser<C,T>::pnode>::node> 
+		parser<C,T>::pnode::nid;
+
+
+template <typename C, typename T>
+typename forest<typename parser<C,T>::pnode>::node 
+	parser<C,T>::pnode::ptrof(
+		const typename parser<C,T>::pnode& pn) {
+	auto r = nid.insert( {pn, (nullptr)} );
+	if (r.second) {
+			//rnid.push_back( &(r.first->first) );
+			nid[pn] = typename parser<C,T>::pforest::node(&(r.first->first));
+			//return rnid.size();
+			return nid[pn];
+	}
+	return r.first->second;
+}
+
+template <typename C, typename T>
 parser<C, T>::item::item(size_t set, size_t prod, size_t con, size_t from,
 	size_t dot) : set(set), prod(prod), con(con), from(from), dot(dot) {}
 template <typename C, typename T>
@@ -854,13 +874,13 @@ bool parser<C, T>::init_forest(pforest& f, const lit<C, T>& start_lit,
 // span of the item and stores them in the set ambset.
 template <typename C, typename T>
 void parser<C, T>::sbl_chd_forest(const item& eitem,
-	std::vector<pnode>& curchd, size_t xfrom,
-	std::set<std::vector<pnode>>& ambset)
+	pnodes& curchd, size_t xfrom,
+	pnodes_set& ambset)
 {
 	//check if we have reached the end of the rhs of prod
 	if (g.len(eitem.prod, eitem.con) <= curchd.size())  {
 		// match the end of the span we are searching in.
-		if (curchd.back().second[1] == eitem.set)
+		if (curchd.back()->second[1] == eitem.set)
 			ambset.insert(curchd);
 		return;
 	}
@@ -903,7 +923,7 @@ void parser<C, T>::sbl_chd_forest(const item& eitem,
 }
 template <typename C, typename T>
 bool parser<C, T>::binarize_comb(const item& eitem,
-	std::set<std::vector<pnode>>& ambset)
+	pnodes_set& ambset)
 {
 	std::vector<pnode> rcomb, lcomb;
 	if (eitem.dot < 1) return false;
@@ -1075,7 +1095,7 @@ bool parser<C, T>::build_forest(pforest& f, const pnode& root) {
 
 	for (auto& aset : (snodes.size() && check_allowed(*snodes.begin()))
 			? cambset : ambset)
-		for (const pnode& nxt : aset) build_forest(f, nxt);
+		for (const auto nxt : aset) build_forest(f, nxt);
 
 	return true;
 }

--- a/src/parser.tmpl.h
+++ b/src/parser.tmpl.h
@@ -461,6 +461,7 @@ parser<C, T>::result parser<C, T>::_parse(const parse_options& po) {
 	auto f = std::make_unique<pforest>();
 	S.clear(), U.clear(), bin_tnt.clear(), refi.clear(),
 		gcready.clear(), sorted_citem.clear(), rsorted_citem.clear();
+	pnode::nid.clear();
 	MS(int gcnt = 0;) // count of collected items
 	tid = 0;
 	S.resize(1);

--- a/src/parser_result.tmpl.h
+++ b/src/parser_result.tmpl.h
@@ -340,7 +340,7 @@ bool parser<C, T>::result::inline_prefixed_nodes(pgraph& g,
 	const std::string& prefix)
 {
 	//collect all prefix like nodes for replacement
-	std::vector<pnode> s;
+	pnodes s;
 	for (auto& kv : f->g) {
 		auto name = kv.first->first.to_std_string();
 		if (name.find(prefix) != decltype(name)::npos)

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -231,14 +231,14 @@ bool run_test_(grammar<T>& g, parser<T>& p, const std::basic_string<T>& input,
 	bool contained = false;
 	if (found && (opts.dump || opts.contains.size())) {
 		auto cb_enter = [&opts, &contained, &ss] (const auto& n) {
-			if (opts.contains == n.first.to_std_string())
+			if (opts.contains == n->first.to_std_string())
 				contained = true;
 			if (opts.dump) ss << "\t#\t entering: \"" <<
-				n.first.to_std_string() << "\"\n";
+				n->first.to_std_string() << "\"\n";
 		};
 		auto cb_exit = [&opts, &ss](const auto& n, const auto&) {
 			if (opts.dump) ss << "\t#\t exiting: \"" <<
-				n.first.to_std_string() << "\"\n";
+				n->first.to_std_string() << "\"\n";
 		};
 		f->traverse(cb_enter, cb_exit);
 	}

--- a/tools/tgf/tgf_cli.cpp
+++ b/tools/tgf/tgf_cli.cpp
@@ -341,13 +341,13 @@ ostream& tgf_repl_evaluator::pretty_print(ostream& os,
 	const parser_type::psptree& n, set<size_t> skip = {},
 	bool nulls = false, size_t l = 0)
 {
-	auto& value = n->value;
-	if (skip.size() && n->value.first.nt() &&
-		skip.find(n->value.first.n()) != skip.end())
+	parser_type::pnode value = n->value;
+	if (skip.size() && value.first.nt() &&
+		skip.find(value.first.n()) != skip.end())
 			return os;
-	if (!nulls && n->value.first.is_null()) return os;
+	if (!nulls && value.first.is_null()) return os;
 	for (size_t t = 0; t < l; t++) os << "\t";
-	if (n->value.first.nt())
+	if (value.first.nt())
 		os << TC_NT << value.first << TC.CLEAR() << TC_NT_ID
 			<< "(" << value.first.n() << ")" << TC.CLEAR();
 	else if (value.first.is_null())


### PR DESCRIPTION
Refactoring the node of forest in order to avoid multiple copies of the same node content within forest
Stores pointer (nptr_t) to the node instead inside the forest.
Now forest is made up of nptr_t i.e a wrapper over pnode*.
There are overload operators to turn ntpr_t to pnode and vice-versa. Didnot use conversion operator as these are slow.
All nodes that are inserted in forest are stored internally in pnode::nid , which keeps unique copy and returns pointer to the same instance. ( only when pnode is inserted in forest that we use nptr_t, other wise pnode and its memory management remains independent)..

The goal has been to keep as minimal code changes, clean and readable as much as possible. This is one of the possible designs that relies on implicit operator overloading between nptr_t and pnode.


