### PR TITLE
Refactor node forest refcount

### DIFF
--- a/src/forest.h
+++ b/src/forest.h
@@ -42,22 +42,42 @@ namespace idni {
 
 template <typename NodeT>
 struct forest { 
+	
+	// node pointer in forerst
 	struct nptr_t {
 		const NodeT *id;	
-	
-		nptr_t(const NodeT *_id = nullptr) : id(_id) { }
-
+		static size_t nc;
+		nptr_t(const NodeT *_id = nullptr) : id(_id) { if(id) nc++; }
+		nptr_t(const nptr_t& rhs) {  id = rhs.id; if(id) nc++;}
+		nptr_t(const nptr_t&& rhs) {  id = rhs.id; if(id) nc++;}
 		inline operator NodeT() const{
 			return *id;
 		}
 		//inline const NodeT& getobj() const { return *id; }
 		inline const NodeT* operator->() const { return id;}
+		inline nptr_t& operator=(const nptr_t& rhs) {
+			if(!id && rhs.id != nullptr ) nc++;
+			id = rhs.id;
+			return *this;
+		}
+		inline nptr_t& operator=(const nptr_t&& rhs) {	 
+			 if(!id && rhs.id != nullptr ) nc++;
+			 id = rhs.id;
+			 return *this;
+		}
 		inline bool operator<(const nptr_t& rhs) const {
 			return id < rhs.id;
 		}
 		inline bool operator == (const nptr_t& rhs) const {
 			return id == rhs.id;
 		}
+		~nptr_t() { 
+			//DBG( assert(nc!=0));
+			DBG(std::cout <<"-"<< NodeT::nid.size() <<" "<<nc );
+			if(id != nullptr) nc--, id = 0 ; 
+			//if(nc == NodeT::nid.size() && NodeT::nid.size()) NodeT::nid.clear();
+		}
+
 		//inline lit<C,T> &first() const { DBG(assert(id!=0)); return id->first; }
 		//inline std::array<size_t, 2>& second() const { DBG(assert(id!=0)); return id->second; } 	
 	};
@@ -69,8 +89,7 @@ struct forest {
 	using edge       = std::pair<size_t, size_t>;
 	public:
 	
-	// node pointer in forerst
-	
+
 	struct tree {
 		node value;
 		std::vector<std::shared_ptr<struct tree>> child;
@@ -162,6 +181,9 @@ private:
 		std::vector<node>& todo, graphv& graphs, size_t gid,
 		cb_next_graph_t g, bool& no_stop) const;
 };
+
+template<typename NodeT>
+size_t forest<NodeT>::nptr_t::nc = 0;
 
 } // idni namespace
 #include "forest.tmpl.h"  // template definitions for forest

--- a/src/parser.h
+++ b/src/parser.h
@@ -218,6 +218,7 @@ public:
 	using parser_type     = idni::parser<char_type, terminal_type>;
 	
 	struct pnode : public node_type {
+		friend forest<pnode>;
 		private:
 	   	static typename forest<pnode>::node ptrof(const pnode& p);
 		static std::map<const pnode, typename forest<pnode>::node> nid;
@@ -227,6 +228,9 @@ public:
 			node_type(_f,_s) {}
 		inline operator typename forest<pnode>::node() const {
 			return ptrof(*this);
+		}
+		inline size_t _mpsize() const {
+			return nid.size();
 		}
 		//inline lit<C,T> &first() const { return this->first; }
 		//inline std::array<size_t, 2>& second() const { return this->second; } 	

--- a/src/parser.h
+++ b/src/parser.h
@@ -220,12 +220,11 @@ public:
 	struct pnode : public node_type {
 		private:
 	   	static typename forest<pnode>::node ptrof(const pnode& p);
+		static std::map<const pnode, typename forest<pnode>::node> nid;
 		public:
 		pnode(){}
 		pnode(const lit<C,T> &_f, const std::array<size_t,2> &_s): 
 			node_type(_f,_s) {}
-			// every pnode object has its pointer
-       	static std::map<const pnode, typename forest<pnode>::node> nid;
 		inline operator typename forest<pnode>::node() const {
 			return ptrof(*this);
 		}

--- a/src/parser.h
+++ b/src/parser.h
@@ -218,11 +218,8 @@ public:
 	using parser_type     = idni::parser<char_type, terminal_type>;
 	
 	struct pnode : public node_type {
-		//using pnodebase::pnodebase;
 		private:
-	  	//static std::vector<const pnode*> rnid;       
-       	static typename forest<pnode>::node ptrof(const pnode& p);
-		//static pnode& pndof(const nptr_t& );
+	   	static typename forest<pnode>::node ptrof(const pnode& p);
 		public:
 		pnode(){}
 		pnode(const lit<C,T> &_f, const std::array<size_t,2> &_s): 
@@ -230,7 +227,6 @@ public:
 			// every pnode object has its pointer
        	static std::map<const pnode, typename forest<pnode>::node> nid;
 		inline operator typename forest<pnode>::node() const {
-			//forest<pnode>::node::nc++;
 			return ptrof(*this);
 		}
 		//inline lit<C,T> &first() const { return this->first; }

--- a/src/parser.h
+++ b/src/parser.h
@@ -230,6 +230,7 @@ public:
 			// every pnode object has its pointer
        	static std::map<const pnode, typename forest<pnode>::node> nid;
 		inline operator typename forest<pnode>::node() const {
+			//forest<pnode>::node::nc++;
 			return ptrof(*this);
 		}
 		//inline lit<C,T> &first() const { return this->first; }

--- a/src/parser.tmpl.h
+++ b/src/parser.tmpl.h
@@ -33,13 +33,10 @@ template <typename C, typename T>
 typename forest<typename parser<C,T>::pnode>::node 
 	parser<C,T>::pnode::ptrof(
 		const typename parser<C,T>::pnode& pn) {
-	auto r = nid.insert( {pn, nullptr} );
-	if (r.second) {
-			//rnid.push_back( &(r.first->first) );
-			nid[pn] = typename parser<C,T>::pforest::node(&(r.first->first));
-			//return rnid.size();
-			return nid[pn];
-	}
+	auto r = nid.emplace( pn, nullptr );
+	if (r.second) r.first->second.id = &(r.first->first);
+		// r.first->second = typename 
+		// forest<typename parser<C,T>::pnode>::node(&(r.first->first));		
 	return r.first->second;
 }
 
@@ -882,7 +879,7 @@ void parser<C, T>::sbl_chd_forest(const item& eitem,
 	//check if we have reached the end of the rhs of prod
 	if (g.len(eitem.prod, eitem.con) <= curchd.size())  {
 		// match the end of the span we are searching in.
-		if (curchd.back()->second[1] == eitem.set)
+		if ( curchd.back()->second[1] == eitem.set)
 			ambset.insert(curchd);
 		return;
 	}

--- a/src/parser.tmpl.h
+++ b/src/parser.tmpl.h
@@ -22,6 +22,7 @@ using namespace idni::term;
 
 static inline term::colors TC;
 
+
 template <typename C, typename T>
 std::map<const typename parser<C,T>::pnode, 
 	typename forest<typename parser<C,T>::pnode>::node> 
@@ -32,7 +33,7 @@ template <typename C, typename T>
 typename forest<typename parser<C,T>::pnode>::node 
 	parser<C,T>::pnode::ptrof(
 		const typename parser<C,T>::pnode& pn) {
-	auto r = nid.insert( {pn, (nullptr)} );
+	auto r = nid.insert( {pn, nullptr} );
 	if (r.second) {
 			//rnid.push_back( &(r.first->first) );
 			nid[pn] = typename parser<C,T>::pforest::node(&(r.first->first));
@@ -461,7 +462,7 @@ parser<C, T>::result parser<C, T>::_parse(const parse_options& po) {
 	auto f = std::make_unique<pforest>();
 	S.clear(), U.clear(), bin_tnt.clear(), refi.clear(),
 		gcready.clear(), sorted_citem.clear(), rsorted_citem.clear();
-	pnode::nid.clear();
+	//pnode::nid.clear();
 	MS(int gcnt = 0;) // count of collected items
 	tid = 0;
 	S.resize(1);
@@ -1096,7 +1097,7 @@ bool parser<C, T>::build_forest(pforest& f, const pnode& root) {
 
 	for (auto& aset : (snodes.size() && check_allowed(*snodes.begin()))
 			? cambset : ambset)
-		for (const auto nxt : aset) build_forest(f, nxt);
+		for (const auto &nxt : aset) build_forest(f, nxt);
 
 	return true;
 }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 			p4 = f(p1);
 			n3 = p4;
 		}
-		cout<<"End , GCed:"<<(assert( parser<>::pnode::nid.size() == 0),"yes");
+		cout<<"End , GCed:"<<(assert( n1._mpsize() == 0),"yes");
 
 
 

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -45,12 +45,32 @@ int main(int argc, char **argv)
 		enabled(nt("enabled")), disabled(nt("disabled")),
 		number(nt("number")),  digits(nt("digits")),
 		q_str(lit<>{'"'}), esc(lit<>{'\\'}), escape(nt("escape"));
+	
+		parser<>::pnode n1, n2,n3;
+		{
+			cout<<"START Ref counting tests "<<std::endl;
+			n2.second ={ 1,1};
+			const parser<>::forest_type::node p1 = n1;
+			parser<>::forest_type::node p4, p2 = n1;
+			*(&p2) = 0;
+			p2 = p1;
+			p2 = n2;
+			p2 = p4;
+			
+			auto f= [p1,&p2](auto a){
+				return	p2 = a;
+				
+			};
+			p4 = f(p1);
+			n3 = p4;
+		}
+		cout<<"End , GCed:"<<(assert( parser<>::pnode::nid.size() == 0),"yes");
+
 
 
 /*******************************************************************************
 *       BASIC
 *******************************************************************************/
-	{
 	// null
 	TEST("basic", "null")
 	ps(start, nll);
@@ -75,7 +95,7 @@ int main(int argc, char **argv)
 	o.error_expected = "Unexpected 'a' at 1:4 (4)";
 	run_test<char>(ps, nt, start, "abcabc", {}, o);
 	ps.clear();
-
+	{
 	TEST("basic", "terminal")
 	ps(start, a | one | plus | lf);
 	run_test<char>(ps, nt, start, "a");
@@ -92,7 +112,7 @@ int main(int argc, char **argv)
 	run_test<char>(ps, nt, start, "\r", {}, o);
 	o.error_expected = "";
 	ps.clear();
-
+	}
 	// char classes
 	TEST("basic", "char_classes")
 	ps(start, digit | alpha);
@@ -437,7 +457,7 @@ int main(int argc, char **argv)
 		if (testing::verbosity > 0)
 			cout << "stress test finished" << endl;
 	}
-	}
+	
 	cout << endl;
 	if (testing::failed) cout << "FAILED\n";
 	return testing::failed ? 1 : 0;

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
 /*******************************************************************************
 *       BASIC
 *******************************************************************************/
-
+	{
 	// null
 	TEST("basic", "null")
 	ps(start, nll);
@@ -437,7 +437,7 @@ int main(int argc, char **argv)
 		if (testing::verbosity > 0)
 			cout << "stress test finished" << endl;
 	}
-
+	}
 	cout << endl;
 	if (testing::failed) cout << "FAILED\n";
 	return testing::failed ? 1 : 0;


### PR DESCRIPTION
Does refcounting for ndptr_t. Once all pointers go out of scope, the map is erased.
This is better than maintaining per pnode ref counter( as in shared_ptr).
