### PR TITLE
Removed pull request trigger from Doxygen deployment

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -2,7 +2,6 @@ name: Doxygen deployment
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
Now Doxygen documentation should be built and deployed only on push to master or when started manually.